### PR TITLE
the rpm build phase cannot reach the tarball generated by setup.py

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -173,12 +173,12 @@ then
     *.tar.bz2)
       echo "-----> Creating source archive (using setup.py): $source_file"
       $python setup.py sdist --formats=bztar 2>&1 | indent
-      mv dist/*.tar.bz2 .
+      mv dist/*.tar.bz2 $source_dir
       ;;
     *.tar.gz)
       echo "-----> Creating source archive (using setup.py): $source_file"
       $python setup.py sdist --formats=gztar 2>&1 | indent
-      mv dist/*.tar.gz .
+      mv dist/*.tar.gz $source_dir
       ;;
     *)
       echo "       error: Don't know how to create source archive (using setup.py): $source_file"


### PR DESCRIPTION
- move the tarball to $source_dir

I don't know exactly the why but without this fix the build fail in packagelabs.com

In my project hardion/python-vxi11 the spec file has been generated by setup.py and added to git in package/rpm as I see this prefix in the detect script.

 python setup.py bdist_rpm --spec-only
 mv *.spec package/rpm

We usually don't push the spec file in git but generate the rpm from setup.py
